### PR TITLE
[ASM-6282] Add handling for aws lambda

### DIFF
--- a/AwsCloudIdProvider.cs
+++ b/AwsCloudIdProvider.cs
@@ -114,6 +114,22 @@ namespace akeyless.Cloudid
                 return SignRequest(accessKey, secretKey, securityToken);
             }
 
+            // if failed, try to take from environment
+            // Apperantly lambda functions use env vars and not profiles
+             try {
+                var profileCreds = new Amazon.Runtime.EnvironmentVariablesAWSCredentials();
+                var creds = await profileCreds.GetCredentialsAsync();
+                var accessKey = creds.AccessKey;
+                var secretKey = creds.SecretKey;
+                var securityToken = creds.Token;
+                if (accessKey != "" && secretKey != "") {
+                    return SignRequest(accessKey, secretKey, securityToken);
+                }
+            } catch (Exception)
+            {
+                // Do nothing on failure, since we want to try the Instance Profile
+            }
+
             // if failed, take from current session
             try {
                 var profileCreds = new Amazon.Runtime.InstanceProfileAWSCredentials();

--- a/akeyless-dotnet-cloudid.csproj
+++ b/akeyless-dotnet-cloudid.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/akeylesslabs/akeyless-netcore-cloud-id</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://akeyless.atlassian.net/browse/ASM-6282

AWS lambda apparently do not use `InstanceProfileAWSCredentials` to set the credentials, but rather injects them via environment variables.  