### PR TITLE
Support Alibaba Cloud identity

### DIFF
--- a/AlibabaCloudIdProvider.cs
+++ b/AlibabaCloudIdProvider.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace akeyless.Cloudid
+{
+    public class AlibabaCloudIdProvider : ICloudIdProvider
+    {
+        internal const string DefaultRegion = "cn-hangzhou";
+        internal const string StsDomain = "sts.aliyuncs.com";
+        internal const string StsApiVersion = "2015-04-01";
+        internal const string StsApiAction = "GetCallerIdentity";
+        internal const string StsApiFormat = "JSON";
+        internal const string SignatureMethod = "HMAC-SHA1";
+
+        public string GetCloudId()
+        {
+            string token = "";
+            var cont = GetCloudIdAsync().ContinueWith(cloudIdTaskRes =>
+            {
+                token = cloudIdTaskRes.Result;
+            });
+            cont.Wait();
+            return token;
+        }
+
+        public async Task<string> GetCloudIdAsync()
+        {
+            var creds = await ResolveCredentialsAsync();
+            var region = ResolveRegion();
+            if (string.IsNullOrEmpty(region))
+            {
+                region = DefaultRegion;
+            }
+            return SignRequest(creds.AccessKeyId, creds.AccessKeySecret, creds.SecurityToken, region,
+                DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"), Guid.NewGuid().ToString("N"));
+        }
+
+        internal string SignRequest(string accessKeyId, string accessKeySecret, string securityToken, string region, string timestamp, string nonce)
+        {
+            if (string.IsNullOrEmpty(region))
+            {
+                region = DefaultRegion;
+            }
+            if (string.IsNullOrEmpty(accessKeyId) || string.IsNullOrEmpty(accessKeySecret))
+            {
+                throw new Exception("alibaba credentials are missing access key id or secret");
+            }
+
+            var queryParams = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["AccessKeyId"] = accessKeyId,
+                ["Action"] = StsApiAction,
+                ["Format"] = StsApiFormat,
+                ["RegionId"] = region,
+                ["SignatureMethod"] = SignatureMethod,
+                ["SignatureNonce"] = nonce,
+                ["SignatureType"] = "",
+                ["SignatureVersion"] = "1.0",
+                ["Timestamp"] = timestamp,
+                ["Version"] = StsApiVersion,
+            };
+            if (!string.IsNullOrEmpty(securityToken))
+            {
+                queryParams["SecurityToken"] = securityToken;
+            }
+
+            var stringToSign = BuildRpcStringToSign("POST", queryParams);
+            queryParams["Signature"] = ShaHmac1(stringToSign, accessKeySecret + "&");
+
+            var requestUrl = "https://" + StsDomain + "/?" + EncodeQueryParams(queryParams);
+            var headers = new Dictionary<string, string[]>
+            {
+                ["Content-Type"] = new[] { "application/x-www-form-urlencoded" },
+                ["X-Acs-Action"] = new[] { StsApiAction },
+                ["X-Acs-Version"] = new[] { StsApiVersion },
+            };
+
+            var payload = new Dictionary<string, string>
+            {
+                ["sts_request_method"] = "POST",
+                ["sts_request_url"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(requestUrl)),
+                ["sts_request_body"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("")),
+                ["sts_request_headers"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(headers))),
+            };
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(payload)));
+        }
+
+        internal static string BuildRpcStringToSign(string method, IDictionary<string, string> queryParams)
+        {
+            var encoded = EncodeQueryParams(queryParams);
+            encoded = encoded.Replace("+", "%20").Replace("*", "%2A").Replace("%7E", "~");
+            return method + "&%2F&" + QueryEscape(encoded);
+        }
+
+        internal static string EncodeQueryParams(IDictionary<string, string> paramsDict)
+        {
+            var parts = new List<string>();
+            foreach (var item in paramsDict)
+            {
+                parts.Add(QueryEscape(item.Key) + "=" + QueryEscape(item.Value ?? ""));
+            }
+            return string.Join("&", parts);
+        }
+
+        internal static string ShaHmac1(string source, string secret)
+        {
+            using (var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(secret)))
+            {
+                return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(source)));
+            }
+        }
+
+        internal static string QueryEscape(string value)
+        {
+            return Uri.EscapeDataString(value ?? "").Replace("%20", "+").Replace("%7E", "~");
+        }
+
+        internal static string ResolveRegion()
+        {
+            foreach (var key in new[] { "ALIBABA_CLOUD_REGION_ID", "ALIBABA_CLOUD_REGION", "REGION_ID" })
+            {
+                var value = Environment.GetEnvironmentVariable(key);
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value.Trim();
+                }
+            }
+            return "";
+        }
+
+        private static async Task<AlibabaCredentials> ResolveCredentialsAsync()
+        {
+            var accessKeyId = FirstEnv("ALIBABA_CLOUD_ACCESS_KEY_ID", "ALICLOUD_ACCESS_KEY");
+            var accessKeySecret = FirstEnv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "ALICLOUD_SECRET_KEY");
+            var securityToken = FirstEnv("ALIBABA_CLOUD_SECURITY_TOKEN", "ALICLOUD_SECURITY_TOKEN");
+            if (!string.IsNullOrEmpty(accessKeyId) && !string.IsNullOrEmpty(accessKeySecret))
+            {
+                return new AlibabaCredentials(accessKeyId, accessKeySecret, securityToken);
+            }
+            return await ResolveEcsRamRoleCredentialsAsync();
+        }
+
+        private static async Task<AlibabaCredentials> ResolveEcsRamRoleCredentialsAsync()
+        {
+            using (var client = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(2) })
+            {
+                var roleName = (await client.GetStringAsync("http://100.100.100.200/latest/meta-data/ram/security-credentials/")).Trim();
+                if (string.IsNullOrEmpty(roleName))
+                {
+                    throw new Exception("alibaba credentials are missing access key id or secret");
+                }
+                var body = await client.GetStringAsync("http://100.100.100.200/latest/meta-data/ram/security-credentials/" + roleName);
+                var json = JObject.Parse(body);
+                return new AlibabaCredentials(
+                    json.Value<string>("AccessKeyId"),
+                    json.Value<string>("AccessKeySecret"),
+                    json.Value<string>("SecurityToken") ?? "");
+            }
+        }
+
+        private static string FirstEnv(params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                var value = Environment.GetEnvironmentVariable(key);
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value.Trim();
+                }
+            }
+            return "";
+        }
+
+        private sealed class AlibabaCredentials
+        {
+            public AlibabaCredentials(string accessKeyId, string accessKeySecret, string securityToken)
+            {
+                AccessKeyId = accessKeyId;
+                AccessKeySecret = accessKeySecret;
+                SecurityToken = securityToken;
+            }
+
+            public string AccessKeyId { get; }
+            public string AccessKeySecret { get; }
+            public string SecurityToken { get; }
+        }
+    }
+}

--- a/AlibabaCloudIdProvider.cs
+++ b/AlibabaCloudIdProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,21 +17,32 @@ namespace akeyless.Cloudid
         internal const string StsApiAction = "GetCallerIdentity";
         internal const string StsApiFormat = "JSON";
         internal const string SignatureMethod = "HMAC-SHA1";
+        internal const string EcsMetadataBaseUrl = "http://100.100.100.200";
+        internal const string EcsMetadataTokenPath = "/latest/api/token";
+        internal const string EcsRamCredentialsPath = "/latest/meta-data/ram/security-credentials/";
+        internal const string EcsMetadataTokenHeader = "X-aliyun-ecs-metadata-token";
+        internal const string EcsMetadataTokenTtlHeader = "X-aliyun-ecs-metadata-token-ttl-seconds";
+        internal const string EcsMetadataTokenTtlSeconds = "60";
+
+        private readonly HttpMessageHandler _metadataHandler;
+
+        public AlibabaCloudIdProvider()
+        {
+        }
+
+        internal AlibabaCloudIdProvider(HttpMessageHandler metadataHandler)
+        {
+            _metadataHandler = metadataHandler;
+        }
 
         public string GetCloudId()
         {
-            string token = "";
-            var cont = GetCloudIdAsync().ContinueWith(cloudIdTaskRes =>
-            {
-                token = cloudIdTaskRes.Result;
-            });
-            cont.Wait();
-            return token;
+            return GetCloudIdAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<string> GetCloudIdAsync()
         {
-            var creds = await ResolveCredentialsAsync();
+            var creds = await ResolveCredentialsAsync().ConfigureAwait(false);
             var region = ResolveRegion();
             if (string.IsNullOrEmpty(region))
             {
@@ -133,7 +145,53 @@ namespace akeyless.Cloudid
             return "";
         }
 
-        private static async Task<AlibabaCredentials> ResolveCredentialsAsync()
+        internal static bool IsTruthyEnvValue(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+            value = value.Trim();
+            return value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                   || value.Equals("1", StringComparison.OrdinalIgnoreCase)
+                   || value.Equals("yes", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool IsImdsV1Disabled()
+        {
+            return IsTruthyEnvValue(Environment.GetEnvironmentVariable("ALIBABA_CLOUD_IMDSV1_DISABLED"))
+                   || IsTruthyEnvValue(Environment.GetEnvironmentVariable("ALIBABA_CLOUD_IMDSV1_DISABLE"));
+        }
+
+        internal static HttpRequestMessage CreateImdsV2TokenRequest()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Put, EcsMetadataBaseUrl + EcsMetadataTokenPath);
+            request.Headers.TryAddWithoutValidation(EcsMetadataTokenTtlHeader, EcsMetadataTokenTtlSeconds);
+            return request;
+        }
+
+        internal static HttpRequestMessage CreateImdsGetRequest(string url, string token)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (!string.IsNullOrEmpty(token))
+            {
+                request.Headers.TryAddWithoutValidation(EcsMetadataTokenHeader, token);
+            }
+            return request;
+        }
+
+        internal static string FirstMetadataLine(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return "";
+            }
+            var trimmed = value.Trim();
+            var newline = trimmed.IndexOfAny(new[] { '\r', '\n' });
+            return newline < 0 ? trimmed : trimmed.Substring(0, newline).Trim();
+        }
+
+        private async Task<AlibabaCredentials> ResolveCredentialsAsync()
         {
             var accessKeyId = FirstEnv("ALIBABA_CLOUD_ACCESS_KEY_ID", "ALICLOUD_ACCESS_KEY");
             var accessKeySecret = FirstEnv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "ALICLOUD_SECRET_KEY");
@@ -142,24 +200,72 @@ namespace akeyless.Cloudid
             {
                 return new AlibabaCredentials(accessKeyId, accessKeySecret, securityToken);
             }
-            return await ResolveEcsRamRoleCredentialsAsync();
+            return await ResolveEcsRamRoleCredentialsAsync().ConfigureAwait(false);
         }
 
-        private static async Task<AlibabaCredentials> ResolveEcsRamRoleCredentialsAsync()
+        private async Task<AlibabaCredentials> ResolveEcsRamRoleCredentialsAsync()
         {
-            using (var client = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(2) })
+            using (var client = CreateMetadataClient())
             {
-                var roleName = (await client.GetStringAsync("http://100.100.100.200/latest/meta-data/ram/security-credentials/")).Trim();
+                string token = null;
+                try
+                {
+                    token = await FetchImdsV2TokenAsync(client).ConfigureAwait(false);
+                }
+                catch (Exception) when (!IsImdsV1Disabled())
+                {
+                    token = null;
+                }
+
+                var roleName = FirstMetadataLine(await GetMetadataAsync(client,
+                    EcsMetadataBaseUrl + EcsRamCredentialsPath, token).ConfigureAwait(false));
                 if (string.IsNullOrEmpty(roleName))
                 {
                     throw new Exception("alibaba credentials are missing access key id or secret");
                 }
-                var body = await client.GetStringAsync("http://100.100.100.200/latest/meta-data/ram/security-credentials/" + roleName);
+
+                var body = await GetMetadataAsync(client,
+                    EcsMetadataBaseUrl + EcsRamCredentialsPath + Uri.EscapeDataString(roleName), token)
+                    .ConfigureAwait(false);
                 var json = JObject.Parse(body);
                 return new AlibabaCredentials(
                     json.Value<string>("AccessKeyId"),
                     json.Value<string>("AccessKeySecret"),
                     json.Value<string>("SecurityToken") ?? "");
+            }
+        }
+
+        private HttpClient CreateMetadataClient()
+        {
+            var client = _metadataHandler != null
+                ? new HttpClient(_metadataHandler, disposeHandler: false)
+                : new HttpClient();
+            client.Timeout = TimeSpan.FromSeconds(2);
+            return client;
+        }
+
+        private static async Task<string> FetchImdsV2TokenAsync(HttpClient client)
+        {
+            using (var request = CreateImdsV2TokenRequest())
+            using (var response = await client.SendAsync(request).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+                var token = (await response.Content.ReadAsStringAsync().ConfigureAwait(false)).Trim();
+                if (string.IsNullOrEmpty(token))
+                {
+                    throw new Exception("alibaba ECS metadata token is empty");
+                }
+                return token;
+            }
+        }
+
+        private static async Task<string> GetMetadataAsync(HttpClient client, string url, string token)
+        {
+            using (var request = CreateImdsGetRequest(url, token))
+            using (var response = await client.SendAsync(request).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
         }
 

--- a/CloudIdProviderFactory.cs
+++ b/CloudIdProviderFactory.cs
@@ -19,7 +19,7 @@ namespace akeyless.Cloudid
             {
                 return new GcpCloudIdProvider();
             }
-            else if (accType == "ali_cloud")
+            else if (accType == "alicloud")
             {
                 return new AlibabaCloudIdProvider();
             }

--- a/CloudIdProviderFactory.cs
+++ b/CloudIdProviderFactory.cs
@@ -19,6 +19,10 @@ namespace akeyless.Cloudid
             {
                 return new GcpCloudIdProvider();
             }
+            else if (accType == "ali_cloud")
+            {
+                return new AlibabaCloudIdProvider();
+            }
 
             throw new Exception("Unsupported type: " + accType);
         }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Configuration config = new Configuration();
 config.BasePath = host;
 var api = new V2Api(config);
 
-// Use azure_ad/aws_iam/gcp, according to your cloud provider
+// Use azure_ad/aws_iam/gcp/ali_cloud, according to your cloud provider
 var accessType = "aws_iam";
 var cloudIdProvider = CloudIdProviderFactory.GetCloudIdProvider(accessType);
 var cloudId = cloudIdProvider.GetCloudId();

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Configuration config = new Configuration();
 config.BasePath = host;
 var api = new V2Api(config);
 
-// Use azure_ad/aws_iam/gcp/ali_cloud, according to your cloud provider
+// Use azure_ad/aws_iam/gcp/alicloud, according to your cloud provider
 var accessType = "aws_iam";
 var cloudIdProvider = CloudIdProviderFactory.GetCloudIdProvider(accessType);
 var cloudId = cloudIdProvider.GetCloudId();

--- a/akeyless-dotnet-cloudid.csproj
+++ b/akeyless-dotnet-cloudid.csproj
@@ -22,6 +22,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>AkeylessCloudId.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.105.13" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Google.Apis.Auth" Version="1.56.0" />

--- a/tests/AkeylessCloudId.Tests/AlibabaCloudIdProviderTests.cs
+++ b/tests/AkeylessCloudId.Tests/AlibabaCloudIdProviderTests.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using akeyless.Cloudid;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -46,6 +50,146 @@ namespace AkeylessCloudId.Tests
             Assert.Equal("application/x-www-form-urlencoded", (string)token.Headers["Content-Type"][0]);
             Assert.Equal(AlibabaCloudIdProvider.StsApiAction, (string)token.Headers["X-Acs-Action"][0]);
             Assert.Equal(AlibabaCloudIdProvider.StsApiVersion, (string)token.Headers["X-Acs-Version"][0]);
+        }
+
+        [Fact]
+        public void ImdsV2TokenRequestUsesHardenedHeaders()
+        {
+            using (var request = AlibabaCloudIdProvider.CreateImdsV2TokenRequest())
+            {
+                Assert.Equal(HttpMethod.Put, request.Method);
+                Assert.Equal(
+                    AlibabaCloudIdProvider.EcsMetadataBaseUrl + AlibabaCloudIdProvider.EcsMetadataTokenPath,
+                    request.RequestUri.ToString());
+                Assert.True(request.Headers.TryGetValues(AlibabaCloudIdProvider.EcsMetadataTokenTtlHeader, out var values));
+                Assert.Equal(AlibabaCloudIdProvider.EcsMetadataTokenTtlSeconds, Assert.Single(values));
+            }
+        }
+
+        [Fact]
+        public void ImdsGetRequestIncludesTokenWhenPresent()
+        {
+            using (var request = AlibabaCloudIdProvider.CreateImdsGetRequest(
+                       AlibabaCloudIdProvider.EcsMetadataBaseUrl + AlibabaCloudIdProvider.EcsRamCredentialsPath,
+                       "imds-token"))
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.True(request.Headers.TryGetValues(AlibabaCloudIdProvider.EcsMetadataTokenHeader, out var values));
+                Assert.Equal("imds-token", Assert.Single(values));
+            }
+        }
+
+        [Fact]
+        public void ImdsGetRequestOmitsTokenForV1Fallback()
+        {
+            using (var request = AlibabaCloudIdProvider.CreateImdsGetRequest(
+                       AlibabaCloudIdProvider.EcsMetadataBaseUrl + AlibabaCloudIdProvider.EcsRamCredentialsPath,
+                       null))
+            {
+                Assert.False(request.Headers.Contains(AlibabaCloudIdProvider.EcsMetadataTokenHeader));
+            }
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("false", false)]
+        [InlineData("true", true)]
+        [InlineData("TRUE", true)]
+        [InlineData("1", true)]
+        [InlineData("yes", true)]
+        public void TruthyImdsPolicyValues(string value, bool expected)
+        {
+            Assert.Equal(expected, AlibabaCloudIdProvider.IsTruthyEnvValue(value));
+        }
+
+        [Fact]
+        public void FirstMetadataLineUsesFirstRoleName()
+        {
+            Assert.Equal("AliyunECSRole", AlibabaCloudIdProvider.FirstMetadataLine("AliyunECSRole\nSecondRole\n"));
+        }
+
+        [Fact]
+        public async Task EcsRamRoleUsesImdsV2Token()
+        {
+            using (new EnvScope(
+                       ("ALIBABA_CLOUD_ACCESS_KEY_ID", null),
+                       ("ALICLOUD_ACCESS_KEY", null),
+                       ("ALIBABA_CLOUD_ACCESS_KEY_SECRET", null),
+                       ("ALICLOUD_SECRET_KEY", null),
+                       ("ALIBABA_CLOUD_SECURITY_TOKEN", null),
+                       ("ALICLOUD_SECURITY_TOKEN", null),
+                       ("ALIBABA_CLOUD_IMDSV1_DISABLED", null),
+                       ("ALIBABA_CLOUD_IMDSV1_DISABLE", null)))
+            {
+                var handler = new StubImdsHandler(requireToken: true);
+                var cloudId = await new AlibabaCloudIdProvider(handler).GetCloudIdAsync();
+                var token = Decode(cloudId);
+
+                Assert.True(handler.TokenRequested);
+                Assert.True(handler.RoleNameUsedToken);
+                Assert.True(handler.CredentialsUsedToken);
+                Assert.Equal("STS.AKID", Query(token.Url)["AccessKeyId"]);
+                Assert.Equal("STSTOKEN", Query(token.Url)["SecurityToken"]);
+            }
+        }
+
+        [Fact]
+        public async Task EcsRamRoleFallsBackToImdsV1WhenTokenRequestFails()
+        {
+            using (new EnvScope(
+                       ("ALIBABA_CLOUD_ACCESS_KEY_ID", null),
+                       ("ALICLOUD_ACCESS_KEY", null),
+                       ("ALIBABA_CLOUD_ACCESS_KEY_SECRET", null),
+                       ("ALICLOUD_SECRET_KEY", null),
+                       ("ALIBABA_CLOUD_SECURITY_TOKEN", null),
+                       ("ALICLOUD_SECURITY_TOKEN", null),
+                       ("ALIBABA_CLOUD_IMDSV1_DISABLED", null),
+                       ("ALIBABA_CLOUD_IMDSV1_DISABLE", null)))
+            {
+                var handler = new StubImdsHandler(requireToken: false, failTokenRequest: true);
+                var cloudId = await new AlibabaCloudIdProvider(handler).GetCloudIdAsync();
+                var token = Decode(cloudId);
+
+                Assert.True(handler.TokenRequested);
+                Assert.False(handler.RoleNameUsedToken);
+                Assert.Equal("STS.AKID", Query(token.Url)["AccessKeyId"]);
+            }
+        }
+
+        [Fact]
+        public async Task EcsRamRoleDoesNotFallBackWhenImdsV1Disabled()
+        {
+            using (new EnvScope(
+                       ("ALIBABA_CLOUD_ACCESS_KEY_ID", null),
+                       ("ALICLOUD_ACCESS_KEY", null),
+                       ("ALIBABA_CLOUD_ACCESS_KEY_SECRET", null),
+                       ("ALICLOUD_SECRET_KEY", null),
+                       ("ALIBABA_CLOUD_IMDSV1_DISABLED", "true"),
+                       ("ALIBABA_CLOUD_IMDSV1_DISABLE", null)))
+            {
+                var handler = new StubImdsHandler(requireToken: false, failTokenRequest: true);
+                await Assert.ThrowsAsync<HttpRequestException>(
+                    () => new AlibabaCloudIdProvider(handler).GetCloudIdAsync());
+            }
+        }
+
+        [Fact]
+        public void GetCloudIdUsesEnvironmentCredentialsWithoutMetadata()
+        {
+            using (new EnvScope(
+                       ("ALIBABA_CLOUD_ACCESS_KEY_ID", "ENV.AKID"),
+                       ("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "ENVSECRET"),
+                       ("ALIBABA_CLOUD_SECURITY_TOKEN", null),
+                       ("ALICLOUD_ACCESS_KEY", null),
+                       ("ALICLOUD_SECRET_KEY", null)))
+            {
+                var handler = new StubImdsHandler(requireToken: true);
+                var token = Decode(new AlibabaCloudIdProvider(handler).GetCloudId());
+
+                Assert.False(handler.TokenRequested);
+                Assert.Equal("ENV.AKID", Query(token.Url)["AccessKeyId"]);
+            }
         }
 
         [Fact]
@@ -115,6 +259,103 @@ namespace AkeylessCloudId.Tests
             public string Url { get; set; }
             public string Body { get; set; }
             public JObject Headers { get; set; }
+        }
+
+        private sealed class EnvScope : IDisposable
+        {
+            private readonly List<Action> _restore = new List<Action>();
+
+            public EnvScope(params (string Key, string Value)[] assignments)
+            {
+                foreach (var assignment in assignments)
+                {
+                    var key = assignment.Key;
+                    var previous = Environment.GetEnvironmentVariable(key);
+                    _restore.Add(() => Environment.SetEnvironmentVariable(key, previous));
+                    Environment.SetEnvironmentVariable(key, assignment.Value);
+                }
+            }
+
+            public void Dispose()
+            {
+                for (var i = _restore.Count - 1; i >= 0; i--)
+                {
+                    _restore[i]();
+                }
+            }
+        }
+
+        private sealed class StubImdsHandler : HttpMessageHandler
+        {
+            private readonly bool _requireToken;
+            private readonly bool _failTokenRequest;
+
+            public StubImdsHandler(bool requireToken, bool failTokenRequest = false)
+            {
+                _requireToken = requireToken;
+                _failTokenRequest = failTokenRequest;
+            }
+
+            public bool TokenRequested { get; private set; }
+            public bool RoleNameUsedToken { get; private set; }
+            public bool CredentialsUsedToken { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var path = request.RequestUri.AbsolutePath.TrimEnd('/');
+                var hasToken = false;
+                if (request.Headers.TryGetValues(AlibabaCloudIdProvider.EcsMetadataTokenHeader, out var tokenValues))
+                {
+                    foreach (var value in tokenValues)
+                    {
+                        if (!string.IsNullOrEmpty(value))
+                        {
+                            hasToken = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (request.Method == HttpMethod.Put && path == AlibabaCloudIdProvider.EcsMetadataTokenPath)
+                {
+                    TokenRequested = true;
+                    if (_failTokenRequest)
+                    {
+                        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden));
+                    }
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("imds-token"),
+                    });
+                }
+
+                if (request.Method == HttpMethod.Get && path == AlibabaCloudIdProvider.EcsRamCredentialsPath.TrimEnd('/'))
+                {
+                    RoleNameUsedToken = hasToken;
+                    return Metadata(hasToken, "AliyunECSRole");
+                }
+
+                if (request.Method == HttpMethod.Get && path == (AlibabaCloudIdProvider.EcsRamCredentialsPath + "AliyunECSRole").TrimEnd('/'))
+                {
+                    CredentialsUsedToken = hasToken;
+                    return Metadata(hasToken,
+                        "{\"AccessKeyId\":\"STS.AKID\",\"AccessKeySecret\":\"STSSECRET\",\"SecurityToken\":\"STSTOKEN\"}");
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            private Task<HttpResponseMessage> Metadata(bool hasToken, string body)
+            {
+                if (_requireToken && !hasToken)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden));
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body),
+                });
+            }
         }
     }
 }

--- a/tests/AkeylessCloudId.Tests/AlibabaCloudIdProviderTests.cs
+++ b/tests/AkeylessCloudId.Tests/AlibabaCloudIdProviderTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using akeyless.Cloudid;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace AkeylessCloudId.Tests
+{
+    public class AlibabaCloudIdProviderTests
+    {
+        private const string TestTimestamp = "2026-05-11T10:00:00Z";
+        private const string TestNonce = "fixed-nonce";
+
+        [Fact]
+        public void DefaultRegionUsesHangzhouAndGlobalSts()
+        {
+            var token = Decode(Sign(""));
+            Assert.Equal("POST", token.Method);
+            Assert.StartsWith("https://sts.aliyuncs.com/?", token.Url);
+            Assert.Equal("", token.Body);
+            Assert.Equal(AlibabaCloudIdProvider.DefaultRegion, Query(token.Url)["RegionId"]);
+            Assert.Equal(AlibabaCloudIdProvider.StsApiAction, Query(token.Url)["Action"]);
+            Assert.Equal(AlibabaCloudIdProvider.StsApiVersion, Query(token.Url)["Version"]);
+            Assert.False(string.IsNullOrEmpty(Query(token.Url)["Signature"]));
+        }
+
+        [Fact]
+        public void ConfiguredRegionIsSigned()
+        {
+            var token = Decode(Sign("cn-beijing"));
+            Assert.Equal("cn-beijing", Query(token.Url)["RegionId"]);
+        }
+
+        [Fact]
+        public void IncludesSecurityToken()
+        {
+            var token = Decode(Sign("cn-hangzhou", "SESSION"));
+            Assert.Equal("SESSION", Query(token.Url)["SecurityToken"]);
+        }
+
+        [Fact]
+        public void PayloadHasCompatibleHeaders()
+        {
+            var token = Decode(Sign("cn-hangzhou"));
+            Assert.Equal("application/x-www-form-urlencoded", (string)token.Headers["Content-Type"][0]);
+            Assert.Equal(AlibabaCloudIdProvider.StsApiAction, (string)token.Headers["X-Acs-Action"][0]);
+            Assert.Equal(AlibabaCloudIdProvider.StsApiVersion, (string)token.Headers["X-Acs-Version"][0]);
+        }
+
+        [Fact]
+        public void RpcStringToSignIsDeterministic()
+        {
+            var queryParams = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["AccessKeyId"] = "AKID",
+                ["Action"] = AlibabaCloudIdProvider.StsApiAction,
+                ["Format"] = AlibabaCloudIdProvider.StsApiFormat,
+                ["RegionId"] = AlibabaCloudIdProvider.DefaultRegion,
+                ["SignatureMethod"] = AlibabaCloudIdProvider.SignatureMethod,
+                ["SignatureNonce"] = TestNonce,
+                ["SignatureType"] = "",
+                ["SignatureVersion"] = "1.0",
+                ["Timestamp"] = TestTimestamp,
+                ["Version"] = AlibabaCloudIdProvider.StsApiVersion,
+            };
+
+            var stringToSign = AlibabaCloudIdProvider.BuildRpcStringToSign("POST", queryParams);
+            var signature = AlibabaCloudIdProvider.ShaHmac1(stringToSign, "SECRET&");
+
+            Assert.Equal(
+                "POST&%2F&AccessKeyId%3DAKID%26Action%3DGetCallerIdentity%26Format%3DJSON%26RegionId%3Dcn-hangzhou%26SignatureMethod%3DHMAC-SHA1%26SignatureNonce%3Dfixed-nonce%26SignatureType%3D%26SignatureVersion%3D1.0%26Timestamp%3D2026-05-11T10%253A00%253A00Z%26Version%3D2015-04-01",
+                stringToSign);
+            Assert.Equal("dSCqL2sSKYDmcOcAj2Grhpar/wE=", signature);
+        }
+
+        private static string Sign(string region, string securityToken = "")
+        {
+            return new AlibabaCloudIdProvider().SignRequest("AKID", "SECRET", securityToken, region, TestTimestamp, TestNonce);
+        }
+
+        private static Dictionary<string, string> Query(string url)
+        {
+            var result = new Dictionary<string, string>();
+            var raw = new Uri(url).Query;
+            if (string.IsNullOrEmpty(raw) || raw.Length < 2)
+            {
+                return result;
+            }
+            foreach (var pair in raw.Substring(1).Split('&'))
+            {
+                var parts = pair.Split(new[] { '=' }, 2);
+                var key = Uri.UnescapeDataString(parts[0].Replace("+", " "));
+                var value = parts.Length > 1 ? Uri.UnescapeDataString(parts[1].Replace("+", " ")) : "";
+                result[key] = value;
+            }
+            return result;
+        }
+
+        private static DecodedToken Decode(string cloudId)
+        {
+            var root = JObject.Parse(Encoding.UTF8.GetString(Convert.FromBase64String(cloudId)));
+            return new DecodedToken
+            {
+                Method = (string)root["sts_request_method"],
+                Url = Encoding.UTF8.GetString(Convert.FromBase64String((string)root["sts_request_url"])),
+                Body = Encoding.UTF8.GetString(Convert.FromBase64String((string)root["sts_request_body"])),
+                Headers = JObject.Parse(Encoding.UTF8.GetString(Convert.FromBase64String((string)root["sts_request_headers"]))),
+            };
+        }
+
+        private sealed class DecodedToken
+        {
+            public string Method { get; set; }
+            public string Url { get; set; }
+            public string Body { get; set; }
+            public JObject Headers { get; set; }
+        }
+    }
+}

--- a/tests/AkeylessCloudId.Tests/CloudIdProviderFactoryTests.cs
+++ b/tests/AkeylessCloudId.Tests/CloudIdProviderFactoryTests.cs
@@ -34,6 +34,15 @@ namespace AkeylessCloudId.Tests
             Assert.IsAssignableFrom<ICloudIdProvider>(provider);
         }
 
+        [Fact]
+        public void GetCloudIdProvider_AliCloud_ReturnsAlibabaProvider()
+        {
+            var provider = CloudIdProviderFactory.GetCloudIdProvider("ali_cloud");
+
+            Assert.IsType<AlibabaCloudIdProvider>(provider);
+            Assert.IsAssignableFrom<ICloudIdProvider>(provider);
+        }
+
         [Theory]
         [InlineData("unknown")]
         [InlineData("AWS_IAM")]   // case sensitive: must not match "aws_iam"

--- a/tests/AkeylessCloudId.Tests/CloudIdProviderFactoryTests.cs
+++ b/tests/AkeylessCloudId.Tests/CloudIdProviderFactoryTests.cs
@@ -35,9 +35,9 @@ namespace AkeylessCloudId.Tests
         }
 
         [Fact]
-        public void GetCloudIdProvider_AliCloud_ReturnsAlibabaProvider()
+        public void GetCloudIdProvider_Alicloud_ReturnsAlibabaProvider()
         {
-            var provider = CloudIdProviderFactory.GetCloudIdProvider("ali_cloud");
+            var provider = CloudIdProviderFactory.GetCloudIdProvider("alicloud");
 
             Assert.IsType<AlibabaCloudIdProvider>(provider);
             Assert.IsAssignableFrom<ICloudIdProvider>(provider);

--- a/tests/AkeylessCloudId.Tests/ProviderConstructionTests.cs
+++ b/tests/AkeylessCloudId.Tests/ProviderConstructionTests.cs
@@ -29,5 +29,12 @@ namespace AkeylessCloudId.Tests
             var provider = new AwsCloudIdProvider();
             Assert.IsAssignableFrom<ICloudIdProvider>(provider);
         }
+
+        [Fact]
+        public void AlibabaProvider_ImplementsInterface()
+        {
+            var provider = new AlibabaCloudIdProvider();
+            Assert.IsAssignableFrom<ICloudIdProvider>(provider);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `AlibabaCloudIdProvider` and factory mapping for `alicloud`.
- Sign an Alibaba STS `GetCallerIdentity` request without sending it, using env credentials or an ECS RAM role.
- Encode the same AWS-style cloud-id payload (`sts_request_method`, `sts_request_url`, `sts_request_body`, `sts_request_headers`).
- Resolve region from `ALIBABA_CLOUD_REGION_ID`, `ALIBABA_CLOUD_REGION`, or `REGION_ID`, falling back to `cn-hangzhou`.

## Test plan
- [x] Factory/construction tests plus offline Alibaba signing tests
- [ ] On Alibaba ECS/ACK with a RAM role, `alicloud` returns a valid cloud ID without hardcoded keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Alibaba Cloud identity retrieval support.
  * Supports credentials from environment configuration or ECS RAM roles.
  * Supports secure metadata access with IMDSv2 and optional IMDSv1 fallback.
  * Automatically resolves the region, with a default fallback.
  * Added `alicloud` as the supported Alibaba Cloud provider option.

* **Documentation**
  * Updated the getting-started example to use `alicloud`.

* **Tests**
  * Expanded coverage for credentials, metadata access, fallback behavior, signing, and provider selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->